### PR TITLE
Rename ssoEnabled to isSsoEnabled

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -230,7 +230,7 @@ class _MyAppState extends State<MyApp> {
   StreamSubscription<SessionStateChangeEvent>? _sub;
   bool _loading = false;
   bool _useTransientTokenStorage = false;
-  bool _ssoEnabled = false;
+  bool _isSsoEnabled = false;
   bool _isBiometricEnabled = false;
   bool get _unconfigured {
     return _authgear.endpoint != _endpointController.text ||
@@ -379,11 +379,11 @@ class _MyAppState extends State<MyApp> {
                     padding:
                         const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
                     child: SwitchWithLabel(
-                      label: "SSO Enabled",
-                      value: _ssoEnabled,
+                      label: "Is SSO Enabled",
+                      value: _isSsoEnabled,
                       onChanged: (newValue) {
                         setState(() {
-                          _ssoEnabled = newValue;
+                          _isSsoEnabled = newValue;
                         });
                       },
                     )),
@@ -731,7 +731,7 @@ class _MyAppState extends State<MyApp> {
     final authgear = Authgear(
       endpoint: endpoint,
       clientID: clientID,
-      ssoEnabled: _ssoEnabled,
+      isSsoEnabled: _isSsoEnabled,
       tokenStorage: _useTransientTokenStorage ? TransientTokenStorage() : null,
       sendWechatAuthRequest: _sendWechatAuthRequest,
     );

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -9,7 +9,7 @@ class OIDCAuthenticationRequest {
   final String clientID;
   final String redirectURI;
   final String responseType;
-  final bool ssoEnabled;
+  final bool isSsoEnabled;
   final List<String> scope;
   final String? codeChallenge;
   final String? state;
@@ -27,7 +27,7 @@ class OIDCAuthenticationRequest {
     required this.redirectURI,
     required this.responseType,
     required this.scope,
-    required this.ssoEnabled,
+    required this.isSsoEnabled,
     this.codeChallenge,
     this.state,
     this.prompt,
@@ -101,14 +101,14 @@ class OIDCAuthenticationRequest {
       q["x_page"] = page.name;
     }
 
-    final ssoEnabled = this.ssoEnabled;
-    if (ssoEnabled == false) {
+    final isSsoEnabled = this.isSsoEnabled;
+    if (isSsoEnabled == false) {
       // For backward compatibility
       // If the developer updates the SDK but not the server
       q["x_suppress_idp_session_cookie"] = "true";
     }
 
-    q["x_sso_enabled"] = ssoEnabled ? "true" : "false";
+    q["x_sso_enabled"] = isSsoEnabled ? "true" : "false";
 
     final wechatRedirectURI = this.wechatRedirectURI;
     if (wechatRedirectURI != null) {

--- a/lib/src/container.dart
+++ b/lib/src/container.dart
@@ -38,7 +38,7 @@ class Authgear implements AuthgearHttpClientDelegate {
   final String clientID;
   final String endpoint;
   final String name;
-  final bool ssoEnabled;
+  final bool isSsoEnabled;
   final Future<void> Function(String)? sendWechatAuthRequest;
 
   final TokenStorage _tokenStorage;
@@ -88,7 +88,7 @@ class Authgear implements AuthgearHttpClientDelegate {
     required this.clientID,
     required this.endpoint,
     this.name = "default",
-    this.ssoEnabled = false,
+    this.isSsoEnabled = false,
     this.sendWechatAuthRequest,
     TokenStorage? tokenStorage,
   })  : _tokenStorage = tokenStorage ?? PersistentTokenStorage(),
@@ -134,7 +134,7 @@ class Authgear implements AuthgearHttpClientDelegate {
         "offline_access",
         "https://authgear.com/scopes/full-access",
       ],
-      ssoEnabled: ssoEnabled,
+      isSsoEnabled: isSsoEnabled,
       codeChallenge: codeVerifier.codeChallenge,
       prompt: prompt,
       uiLocales: uiLocales,
@@ -148,7 +148,7 @@ class Authgear implements AuthgearHttpClientDelegate {
     final resultURL = await native.authenticate(
       url: authenticationURL.toString(),
       redirectURI: redirectURI,
-      preferEphemeral: !ssoEnabled,
+      preferEphemeral: !isSsoEnabled,
       wechatRedirectURI: wechatRedirectURI,
       onWechatRedirectURI: _onWechatRedirectURI,
     );
@@ -186,7 +186,7 @@ class Authgear implements AuthgearHttpClientDelegate {
         "openid",
         "https://authgear.com/scopes/full-access",
       ],
-      ssoEnabled: ssoEnabled,
+      isSsoEnabled: isSsoEnabled,
       codeChallenge: codeVerifier.codeChallenge,
       uiLocales: uiLocales,
       colorScheme: colorScheme,
@@ -200,7 +200,7 @@ class Authgear implements AuthgearHttpClientDelegate {
     final resultURL = await native.authenticate(
       url: authenticationURL.toString(),
       redirectURI: redirectURI,
-      preferEphemeral: !ssoEnabled,
+      preferEphemeral: !isSsoEnabled,
       wechatRedirectURI: wechatRedirectURI,
       onWechatRedirectURI: _onWechatRedirectURI,
     );
@@ -243,7 +243,7 @@ class Authgear implements AuthgearHttpClientDelegate {
         "offline_access",
         "https://authgear.com/scopes/full-access",
       ],
-      ssoEnabled: ssoEnabled,
+      isSsoEnabled: isSsoEnabled,
       prompt: [PromptOption.none],
       loginHint: loginHint,
       wechatRedirectURI: wechatRedirectURI,
@@ -500,7 +500,7 @@ class Authgear implements AuthgearHttpClientDelegate {
         "offline_access",
         "https://authgear.com/scopes/full-access",
       ],
-      ssoEnabled: ssoEnabled,
+      isSsoEnabled: isSsoEnabled,
       codeChallenge: codeVerifier.codeChallenge,
       prompt: [PromptOption.login],
       loginHint: loginHint,
@@ -516,7 +516,7 @@ class Authgear implements AuthgearHttpClientDelegate {
       redirectURI: redirectURI,
       wechatRedirectURI: wechatRedirectURI,
       onWechatRedirectURI: _onWechatRedirectURI,
-      preferEphemeral: !ssoEnabled,
+      preferEphemeral: !isSsoEnabled,
     );
     final xDeviceInfo = await _getXDeviceInfo();
     final userInfo = await _finishAuthentication(

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -10,7 +10,7 @@ void main() {
       redirectURI: "http://host/path",
       responseType: "code",
       scope: ["openid", "email"],
-      ssoEnabled: false,
+      isSsoEnabled: false,
       codeChallenge: "codeChallenge",
       state: "state",
       prompt: [PromptOption.login],


### PR DESCRIPTION
ref #14 

Checked the guide, and the argument should be `isSsoEnabled`. Seems other parts of the SDK have not followed the conventions see if we want to correct it now.

https://dart.dev/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words