### PR TITLE
Fix GHSA: ruby-jwt empty-key HMAC bypass

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.10.2)
-    jwt (2.10.1)
+    jwt (2.10.2)
       base64
     logger (1.7.0)
     mini_magick (4.13.2)


### PR DESCRIPTION
Bump jwt from 2.10.1 to 2.10.2 to fix the empty-key HMAC bypass vulnerability (cross-language sibling of CVE-2026-44351).